### PR TITLE
Fixed CS using PHP-CS-Fixer

### DIFF
--- a/Command/GenerateDoctrineCommand.php
+++ b/Command/GenerateDoctrineCommand.php
@@ -12,7 +12,6 @@ use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
  */
 abstract class GenerateDoctrineCommand extends ContainerAwareCommand
 {
-
     /**
      * @param string $shortcut
      *

--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class GenerateDoctrineCrudCommand extends GenerateDoctrineCommand
 {
-
     /**
      * @var DoctrineCrudGenerator
      */
@@ -158,7 +157,7 @@ EOT
      */
     protected function getRoutePrefix(InputInterface $input, $document)
     {
-        $prefix = $input->getOption('route-prefix') ? : strtolower(str_replace(array('\\', '/'), '_', $document));
+        $prefix = $input->getOption('route-prefix') ?: strtolower(str_replace(array('\\', '/'), '_', $document));
 
         if ($prefix && '/' === $prefix[0]) {
             $prefix = substr($prefix, 1);
@@ -219,7 +218,7 @@ EOT
         $question = new Question($dialog->getQuestion('The Document shortcut name', $input->getOption('document')), $input->getOption('document'));
         $question->setValidator(array(
             'IsmaAmbrosi\Bundle\GeneratorBundle\Command\Validators',
-            'validateDocumentName'
+            'validateDocumentName',
         ));
 
         $document = $dialog->ask($input, $output, $question, false, $input->getOption('document'));
@@ -273,7 +272,7 @@ EOT
         }
 
         if ($ret) {
-            return null;
+            return;
         }
 
         $help = sprintf("        <comment>resource: \"@%s/Resources/config/routing/%s.%s\"</comment>\n", $bundle->getName(), strtolower(str_replace('\\', '_', $document)), $format);
@@ -296,7 +295,7 @@ EOT
      */
     private function askForWriteOption(InputInterface $input, OutputInterface $output, QuestionHelper $dialog)
     {
-        $withWrite = $input->getOption('with-write') ? : false;
+        $withWrite = $input->getOption('with-write') ?: false;
         $output->writeln(array(
             '',
             'By default, the generator creates two actions: list and show.',
@@ -326,7 +325,7 @@ EOT
         $question = new Question($dialog->getQuestion('Configuration format (yml, xml, php, or annotation)', $format), $format);
         $question->setValidator(array(
             'Sensio\Bundle\GeneratorBundle\Command\Validators',
-            'validateFormat'
+            'validateFormat',
         ));
 
         $format = $dialog->ask($input, $output, $question);

--- a/Command/GenerateDoctrineDocumentCommand.php
+++ b/Command/GenerateDoctrineDocumentCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Question\Question;
 
 class GenerateDoctrineDocumentCommand extends GenerateDoctrineCommand
 {
-
     /**
      * @var DoctrineDocumentGenerator
      */
@@ -125,7 +124,7 @@ EOT
             '',
             'First, you need to give the document name you want to generate.',
             'You must use the shortcut notation like <comment>AcmeBlogBundle:Post</comment>.',
-            ''
+            '',
         ));
 
         list($bundle, $document) = $this->askForDocument($input, $output, $dialog);
@@ -252,7 +251,7 @@ EOT
             $question = new Question($dialog->getQuestion('The Document shortcut name', $input->getOption('document')), $input->getOption('document'));
             $question->setValidator(array(
                 'IsmaAmbrosi\Bundle\GeneratorBundle\Command\Validators',
-                'validateDocumentName'
+                'validateDocumentName',
             ), $input->getOption('document'));
             $document = $dialog->ask($input, $output, $question);
 

--- a/Command/GenerateDoctrineFormCommand.php
+++ b/Command/GenerateDoctrineFormCommand.php
@@ -9,7 +9,6 @@ use IsmaAmbrosi\Bundle\GeneratorBundle\Generator\DoctrineFormGenerator;
 
 class GenerateDoctrineFormCommand extends GenerateDoctrineCommand
 {
-
     /**
      * {@inheritdoc}
      */

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -11,7 +11,6 @@ use Sensio\Bundle\GeneratorBundle\Command\Validators as BaseValidators;
  */
 class Validators extends BaseValidators
 {
-
     /**
      * Validates the document name
      *

--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -13,7 +13,6 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  */
 class DoctrineCrudGenerator extends Generator
 {
-
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
@@ -313,7 +312,7 @@ class DoctrineCrudGenerator extends Generator
      */
     private function getRecordActions()
     {
-        return array_filter($this->actions, function($item) {
+        return array_filter($this->actions, function ($item) {
             return in_array($item, array('show', 'edit'));
         });
     }

--- a/Generator/DoctrineDocumentGenerator.php
+++ b/Generator/DoctrineDocumentGenerator.php
@@ -16,7 +16,6 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class DoctrineDocumentGenerator extends Generator
 {
-
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
@@ -65,7 +64,7 @@ class DoctrineDocumentGenerator extends Generator
         $class->mapField(array(
             'fieldName' => 'id',
             'type'      => 'integer',
-            'id'        => true
+            'id'        => true,
         ));
         $class->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
         foreach ($fields as $field) {

--- a/Generator/DoctrineFormGenerator.php
+++ b/Generator/DoctrineFormGenerator.php
@@ -12,7 +12,6 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  */
 class DoctrineFormGenerator extends Generator
 {
-
     /**
      * @var string
      */

--- a/Generator/Generator.php
+++ b/Generator/Generator.php
@@ -2,7 +2,7 @@
 
 namespace IsmaAmbrosi\Bundle\GeneratorBundle\Generator;
 
-use \Sensio\Bundle\GeneratorBundle\Generator\Generator as BaseGenerator;
+use Sensio\Bundle\GeneratorBundle\Generator\Generator as BaseGenerator;
 
 /**
  * Class Generator
@@ -11,5 +11,4 @@ use \Sensio\Bundle\GeneratorBundle\Generator\Generator as BaseGenerator;
  */
 class Generator extends BaseGenerator
 {
-
 }

--- a/Tests/Command/GenerateDoctrineCrudCommandTest.php
+++ b/Tests/Command/GenerateDoctrineCrudCommandTest.php
@@ -46,7 +46,7 @@ class GenerateDoctrineCrudCommandTest extends GenerateCommandTest
             array(array('--document'        => 'AcmeBlogBundle:Blog/Post',
                         '--format'          => 'yml',
                         '--route-prefix'    => 'foo',
-                        '--with-write'      => true), '', array('Blog\\Post', 'yml', 'foo', true)),
+                        '--with-write'      => true, ), '', array('Blog\\Post', 'yml', 'foo', true)),
         );
     }
 
@@ -79,7 +79,7 @@ class GenerateDoctrineCrudCommandTest extends GenerateCommandTest
                 '--document'        => 'AcmeBlogBundle:Blog/Post',
                 '--format'          => 'yml',
                 '--route-prefix'    => 'foo',
-                '--with-write'      => true
+                '--with-write'      => true,
             ), array('Blog\\Post', 'yml', 'foo', true)),
         );
     }

--- a/Tests/Command/GenerateDoctrineDocumentCommandTest.php
+++ b/Tests/Command/GenerateDoctrineDocumentCommandTest.php
@@ -41,7 +41,7 @@ class GenerateDoctrineDocumentCommandTest extends GenerateCommandTest
                 array('Blog\\Post', array(
                     array('fieldName' => 'title', 'type' => 'string'),
                     array('fieldName' => 'description', 'type' => 'string'),
-                ))),
+                )), ),
         );
     }
 
@@ -71,7 +71,7 @@ class GenerateDoctrineDocumentCommandTest extends GenerateCommandTest
         return array(
             array(array('--document' => 'AcmeBlogBundle:Blog/Post'), array('Blog\\Post', array())),
             array(array('--document' => 'AcmeBlogBundle:Blog/Post',
-                        '--fields' => 'title:string description:string'), array('Blog\\Post', array(
+                        '--fields' => 'title:string description:string', ), array('Blog\\Post', array(
                 array('fieldName' => 'title', 'type' => 'string'),
                 array('fieldName' => 'description', 'type' => 'string'),
             ))),

--- a/Tests/Generator/DoctrineCrudGeneratorTest.php
+++ b/Tests/Generator/DoctrineCrudGeneratorTest.php
@@ -11,7 +11,6 @@ use IsmaAmbrosi\Bundle\GeneratorBundle\Generator\DoctrineCrudGenerator;
  */
 class DoctrineCrudGeneratorTest extends GeneratorTestCase
 {
-
     public function testAnnotation()
     {
         $prefix    = $this->getPathPrefix();

--- a/Tests/Generator/DoctrineFormGeneratorTest.php
+++ b/Tests/Generator/DoctrineFormGeneratorTest.php
@@ -11,7 +11,6 @@ use IsmaAmbrosi\Bundle\GeneratorBundle\Generator\DoctrineFormGenerator;
  */
 class DoctrineFormGeneratorTest extends GeneratorTestCase
 {
-
     public function testSimpleGenerator()
     {
         $generator = new DoctrineFormGenerator(dirname(dirname(__DIR__)).'/Resources/skeleton/form');

--- a/Tests/Generator/GeneratorTestCase.php
+++ b/Tests/Generator/GeneratorTestCase.php
@@ -12,7 +12,6 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
  */
 abstract class GeneratorTestCase extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var string
      */
@@ -46,17 +45,17 @@ abstract class GeneratorTestCase extends \PHPUnit_Framework_TestCase
         $this->metadata->mapField(array(
             'name'      => 'id',
             'id'        => true,
-            'strategy'  => 'auto'
+            'strategy'  => 'auto',
         ));
 
         $this->metadata->mapField(array(
             'fieldName' => 'name',
-            'type'      => 'string'
+            'type'      => 'string',
         ));
 
         $this->metadata->mapField(array(
             'fieldName' => 'description',
-            'type'      => 'string'
+            'type'      => 'string',
         ));
     }
 

--- a/Tests/autoload.php
+++ b/Tests/autoload.php
@@ -6,7 +6,7 @@ if (!is_readable($file = __DIR__.'/../vendor/autoload.php')) {
 
 require $file;
 
-spl_autoload_register(function($class) {
+spl_autoload_register(function ($class) {
     if (0 === strpos($class, 'IsmaAmbrosi\\Bundle\\GeneratorBundle\\')) {
         $path = __DIR__.'/../'.implode('/', array_slice(explode('\\', $class), 3)).'.php';
         if (!stream_resolve_include_path($path)) {


### PR DESCRIPTION
Using [PHP-CS-Fixer](http://cs.sensiolabs.org/) to fix the coding standards according to Symfony style.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

Result:

```
 1) Command/GenerateDoctrineCommand.php (braces)
 2) Command/GenerateDoctrineCrudCommand.php (empty_return, multiline_array_trailing_comma, ternary_spaces, braces)
 3) Command/GenerateDoctrineDocumentCommand.php (multiline_array_trailing_comma, braces)
 4) Command/GenerateDoctrineFormCommand.php (braces)
 5) Command/Validators.php (braces)
 6) Generator/DoctrineCrudGenerator.php (function_declaration, braces)
 7) Generator/DoctrineDocumentGenerator.php (multiline_array_trailing_comma, braces)
 8) Generator/DoctrineFormGenerator.php (braces)
 9) Generator/Generator.php (remove_leading_slash_use, braces)
10) Tests/autoload.php (function_declaration)
11) Tests/Command/GenerateDoctrineCrudCommandTest.php (multiline_array_trailing_comma)
12) Tests/Command/GenerateDoctrineDocumentCommandTest.php (multiline_array_trailing_comma)
13) Tests/Generator/DoctrineCrudGeneratorTest.php (braces)
14) Tests/Generator/DoctrineFormGeneratorTest.php (braces)
15) Tests/Generator/GeneratorTestCase.php (multiline_array_trailing_comma, braces)
```
