### PR TITLE
Tweak travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,30 @@ php:
   - 5.5
   - 5.6
 
-before_script:
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.3
+      env: SYMFONY_VERSION="v2.5.12"
+    - php: 5.3
+      env: SYMFONY_VERSION="v2.6.11"
+
+before_install:
   - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   - echo 'extension = "mongo.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - composer install --prefer-source --dev
+  - composer self-update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
+
+install: composer update $COMPOSER_FLAGS --prefer-source
 
 script: ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,5 @@
     "autoload": {
         "psr-0": { "IsmaAmbrosi\\Bundle\\GeneratorBundle": "" }
     },
-    "target-dir": "IsmaAmbrosi/Bundle/GeneratorBundle",
-    "minimum-stability": "dev"
+    "target-dir": "IsmaAmbrosi/Bundle/GeneratorBundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "twig/twig": ">=1.4,<2.0-dev",
+        "symfony/dependency-injection": "~2.1",
         "phpunit/phpunit": "~4.2"
     },
     "autoload": {


### PR DESCRIPTION
* Test with lowest dependency versions 
* Include tests with Symfony 2.5 and 2.6, since by default uses the stable version
* Update composer before running tests
* Use only stable versions